### PR TITLE
fix(element,vant): delay `EncForm.clearValidate` method

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,3 +57,11 @@ export function readFileContent(file: File, resultType: 'text' | 'dataUrl') {
     }
   })
 }
+
+export async function delayWrapper<T>(fn: () => T, delay: number) {
+  return new Promise<T>((resolve) => {
+    setTimeout(() => {
+      resolve(fn())
+    }, delay)
+  })
+}

--- a/packages/vue-element-plus/src/components/form/Form.vue
+++ b/packages/vue-element-plus/src/components/form/Form.vue
@@ -2,6 +2,7 @@
 import { type CSSProperties, computed, ref } from 'vue'
 
 import type { FormItemUnion } from '@cphayim-enc/base'
+import { delayWrapper } from '@cphayim-enc/shared'
 
 import { LOCALES } from '../../locales'
 import EncFormItem from './FormItem.vue'
@@ -63,20 +64,22 @@ const validate = async () => {
   if (!formRef.value) return
   // 保持和 vant 一致
   return new Promise((resolve, reject) => {
-    formRef.value!.validate((valid: boolean, fields: any[]) => {
-      if (valid) resolve(undefined)
-      else reject(fields)
+    formRef.value!.validate((isValid: boolean, invalidFields: Record<string, any>) => {
+      if (isValid) resolve(undefined)
+      else reject(invalidFields)
     })
   })
 }
 
-const clearValidate = (names?: string | string[]) => {
+const clearValidate = async (names?: string | string[]) => {
   if (!formRef.value) return
   // @enhance: 当没有传递 names 时，清除所有验证结果
   if (!names) {
     names = props.items.map((item) => item.name)
   }
-  formRef.value!.clearValidate(names)
+  return delayWrapper(() => {
+    formRef.value!.clearValidate(typeof names === 'string' ? [names] : names)
+  }, 0)
 }
 const getValues = () => props.data
 

--- a/packages/vue-vant/src/components/form/Form.vue
+++ b/packages/vue-vant/src/components/form/Form.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 
 import type { FormItemUnion } from '@cphayim-enc/base'
+import { delayWrapper } from '@cphayim-enc/shared'
 
 import EncFormItem from './FormItem.vue'
 
@@ -38,9 +39,9 @@ const validate = async () => {
   return formRef.value.validate()
 }
 
-const clearValidate = (names?: string | string[]) => {
+const clearValidate = async (names?: string | string[]) => {
   if (!formRef.value) return
-  formRef.value!.resetValidation(names)
+  return delayWrapper(() => formRef.value!.resetValidation(names), 0)
 }
 
 const getValues = () => props.data


### PR DESCRIPTION
In some cases, `EncForm.clearValidate()` did not work as expected, now `EncForm.clearValidate()` is an asynchronous function, it will be delayed.

```ts
// now
await formRef.clearValidate()
```