### PR TITLE
fix(element-plus, vant): `EncLayout` icon support relative value conversion, `useLoading` optional parameters

### DIFF
--- a/packages/vue-element-plus/src/hooks/use-loading.ts
+++ b/packages/vue-element-plus/src/hooks/use-loading.ts
@@ -9,7 +9,7 @@ const DURATION = 3000
 
 export function useLoading<T extends unknown[]>(
   fn: (...args: T) => void | Promise<void>,
-  options: UseLoadingOptions,
+  options?: UseLoadingOptions,
 ): (...args: T) => Promise<void> {
   return _useLoading(fn, {
     onLoading: (message) => {

--- a/packages/vue-vant/src/components/layout/Layout.vue
+++ b/packages/vue-vant/src/components/layout/Layout.vue
@@ -95,7 +95,7 @@ const isAndroid = ref(props.platform === 'auto' ? platform.Android : props.platf
           :border="!hideHeaderBorder"
         >
           <template v-if="backArrow" #left>
-            <van-icon name="arrow-left" size="18" @click="handleBack" />
+            <van-icon name="arrow-left" class="enc-text-[18px]" @click="handleBack" />
           </template>
           <template v-else #left>
             <slot name="header-left" />

--- a/packages/vue-vant/src/hooks/use-loading.ts
+++ b/packages/vue-vant/src/hooks/use-loading.ts
@@ -8,7 +8,7 @@ const DURATION = 3000
 
 export function useLoading<T extends unknown[]>(
   fn: (...args: T) => void | Promise<void>,
-  options: UseLoadingOptions,
+  options?: UseLoadingOptions,
 ): (...args: T) => Promise<void> {
   return _useLoading(fn, {
     onLoading: (message) => {


### PR DESCRIPTION
## Bug fixes
- `EncLayout` icon support relative value conversion
- `useLoading` optional parameters