### PR TITLE
feat(vant): `EncInputFormItem` support for display required red dots

### DIFF
--- a/packages/vue-vant/src/components/form/input/InputFormItem.vue
+++ b/packages/vue-vant/src/components/form/input/InputFormItem.vue
@@ -47,6 +47,8 @@ const handleFieldClick = useEventLock(() => {
 })
 
 const slots = useSlots()
+
+const isRequired = computed(() => item.value.rules?.some((rule) => rule.required))
 </script>
 
 <template>
@@ -65,6 +67,7 @@ const slots = useSlots()
     :maxlength="item.inputMaxLength"
     autosize
     show-word-limit
+    :required="isRequired"
     @click="handleFieldClick"
   >
     <template v-if="slots.label" #label><slot name="label" /></template>


### PR DESCRIPTION
## Features

**@cphayim-enc/vue-vant**
- `EncInputFormItem` support for display required red dots