### PR TITLE
fix(shared): `structuredClone` not support `Proxy` objects

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,9 +44,12 @@ export function randomStr(length: number) {
 }
 
 export function deepClone<T>(obj: T): T {
-  return typeof structuredClone !== 'undefined'
-    ? structuredClone(obj)
-    : JSON.parse(JSON.stringify(obj))
+  // issue: Proxy objects have problems with structuredClone
+  // return typeof structuredClone !== 'undefined'
+  //   ? structuredClone(obj)
+  //   : JSON.parse(JSON.stringify(obj))
+
+  return JSON.parse(JSON.stringify(obj))
 }
 
 export function getFileNameFromUrl(url: string) {


### PR DESCRIPTION
## Affected packages

- **@cphayim-enc/shared**

## Bug Fixes

- `structuredClone` not support `Proxy` objects