### PR TITLE
feat(element-plus,vant): implement form label-position

### DIFF
--- a/packages/base/src/form/base/BaseFormItem.ts
+++ b/packages/base/src/form/base/BaseFormItem.ts
@@ -75,12 +75,6 @@ export interface BaseFormItem<F = string, E = any> {
    * @default 'left'
    */
   align?: FormItemAlign
-  /**
-   * label 标签对齐方式
-   *
-   * 默认值：由 UI package 决定，通常 PC 端为 'right'，移动端为 'left'
-   */
-  labelAlign?: FormItemAlign
 }
 
 /**

--- a/packages/vue-element-plus/src/components/form/form/Form.vue
+++ b/packages/vue-element-plus/src/components/form/form/Form.vue
@@ -38,9 +38,15 @@ type Props = {
    */
   colGutter?: number
   /**
-   * 左侧标题宽度 px，默认 100
+   * 左侧标题宽度
+   * @default '100px'
    */
-  labelWidth?: number
+  labelWidth?: number | string
+  /**
+   * 标签的位置
+   * @default 'right'
+   */
+  labelPosition?: 'left' | 'right' | 'top'
   /**
    * 国际化
    */
@@ -55,7 +61,7 @@ const props = withDefaults(defineProps<Props>(), {
   size: 'default',
   rowGutter: 8,
   colGutter: 10,
-  labelWidth: 100,
+  labelWidth: '100px',
   locale: 'zh-cn',
 })
 
@@ -116,8 +122,9 @@ const locale = computed(() => (props.locale === 'en' ? en : zhCn))
         ref="formRef"
         :model="props.data"
         :label-width="props.labelWidth"
-        @submit.prevent
+        :label-position="props.labelPosition"
         :size="props.size"
+        @submit.prevent
       >
         <el-row :gutter="props.colGutter * 2">
           <template v-for="item in props.items" :key="item.name">

--- a/packages/vue-vant/src/components/form/form/Form.vue
+++ b/packages/vue-vant/src/components/form/form/Form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { provide, ref } from 'vue'
 import { Form as VanForm } from 'vant'
 import 'vant/es/form/style/index'
 
@@ -7,6 +7,7 @@ import type { FormItemUnion } from '@cphayim-enc/base'
 import { delayWrapper } from '@cphayim-enc/shared'
 
 import { EncFormItem } from '../form-item'
+import { FormInternalConfig, FORM_INTERNAL_CONFIG_KEY } from './provide'
 
 defineOptions({ name: 'EncForm', inheritAttrs: false })
 
@@ -19,6 +20,16 @@ type Props = {
    * 表单项
    */
   items: FormItemUnion[]
+  /**
+   * 左侧标题宽度
+   * @default '6.2em'
+   */
+  labelWidth?: number | string
+  /**
+   * 标签的位置
+   * @default 'right'
+   */
+  labelPosition?: 'left' | 'right' | 'top'
 }
 
 const props = withDefaults(defineProps<Props>(), {})
@@ -26,6 +37,12 @@ const props = withDefaults(defineProps<Props>(), {})
 const emit = defineEmits<{
   (e: 'update:data', values: any): void
 }>()
+
+// 提供给 form-item 组件使用
+provide<FormInternalConfig>(FORM_INTERNAL_CONFIG_KEY, {
+  labelWidth: props.labelWidth,
+  labelPosition: props.labelPosition,
+})
 
 const formRef = ref<any>()
 

--- a/packages/vue-vant/src/components/form/form/provide.ts
+++ b/packages/vue-vant/src/components/form/form/provide.ts
@@ -1,0 +1,19 @@
+export type FormInternalConfig = {
+  /**
+   * 左侧标题宽度
+   * @default '6.2em'
+   */
+  labelWidth?: number | string
+  /**
+   * 标签的位置
+   * @default 'left'
+   */
+  labelPosition?: 'left' | 'right' | 'top'
+}
+
+export const DEFAULT_FORM_INTERNAL_CONFIG: FormInternalConfig = {
+  labelWidth: '6.2em',
+  labelPosition: 'left',
+}
+
+export const FORM_INTERNAL_CONFIG_KEY = Symbol('FORM_INTERNAL_CONFIG_KEY')

--- a/packages/vue-vant/src/components/form/input/InputFormItem.vue
+++ b/packages/vue-vant/src/components/form/input/InputFormItem.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, inject, useSlots } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { Field as VanField } from 'vant'
 import 'vant/es/field/style/index'
 
 import type { BaseFormItem, InputFormItem } from '@cphayim-enc/base'
 import { useEventLock } from '@cphayim-enc/vue'
+
+import {
+  DEFAULT_FORM_INTERNAL_CONFIG,
+  FormInternalConfig,
+  FORM_INTERNAL_CONFIG_KEY,
+} from '../form/provide'
 
 defineOptions({ name: 'EncInputFormItem' })
 
@@ -48,6 +54,18 @@ const handleFieldClick = useEventLock(() => {
 
 const slots = useSlots()
 
+const formInternalConfig = inject<FormInternalConfig>(
+  FORM_INTERNAL_CONFIG_KEY,
+  DEFAULT_FORM_INTERNAL_CONFIG,
+)
+const labelWidth = computed(() => formInternalConfig.labelWidth)
+const labelAlign = computed(() => formInternalConfig.labelPosition)
+const inputAlign = computed(() => {
+  if (item.value.align) return item.value.align
+  if (labelAlign.value === 'top') return 'left'
+  return item.value.inputType === 'textarea' ? 'left' : 'right'
+})
+
 const isRequired = computed(() => item.value.rules?.some((rule) => rule.required))
 </script>
 
@@ -61,7 +79,9 @@ const isRequired = computed(() => item.value.rules?.some((rule) => rule.required
     :placeholder="item.placeholder"
     :is-link="props._isLink"
     :rules="rules"
-    :input-align="item.align ?? item.inputType === 'textarea' ? 'left' : 'right'"
+    :label-width="labelWidth"
+    :label-align="labelAlign"
+    :input-align="inputAlign"
     :type="item.inputType"
     :rows="item.inputRows"
     :maxlength="item.inputMaxLength"

--- a/scripts/vite.base.config.ts
+++ b/scripts/vite.base.config.ts
@@ -13,10 +13,10 @@ export type CreateOptions = {
   external?: (string | RegExp)[]
 }
 
-export const createBuild = ({ root, external }: CreateOptions) => {
+export const createBuild = ({ root, external, mode }: CreateOptions) => {
   const build: BuildOptions = {
     outDir: resolve(root, 'dist'),
-    emptyOutDir: true,
+    emptyOutDir: mode === 'production',
     sourcemap: true,
     lib: {
       entry: resolve(root, 'src/index.ts'),


### PR DESCRIPTION
## Affected packages

- **@cphayim-enc/vue-element-plus**
- **@cphayim-enc/vue-vant**

## Features

**@cphayim-enc/vue-element-plus**
**@cphayim-enc/vue-vant**

- `EncForm` component adds props `labelPosition`, allowing to set it to `top` to make the label and form controls vertically arranged
