### PR TITLE
feat(base): form enhancements

### DIFF
--- a/packages/base/src/biz-form/__tests__/helper.spec.ts
+++ b/packages/base/src/biz-form/__tests__/helper.spec.ts
@@ -80,7 +80,7 @@ describe('BizFormHelper', () => {
     createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key1', bizField: 'Biz2Field2' }),
     createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key2', bizField: 'Biz2Field1' }), // second group
     createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key2', bizField: 'Biz2Field2' }),
-  ] as const
+  ]
 
   it('should be able to filter `BizFormItemUnion[]`', () => {
     // all `BizFormItemUnion`

--- a/packages/base/src/biz-form/__tests__/helper.spec.ts
+++ b/packages/base/src/biz-form/__tests__/helper.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FormItemUnion } from '../../form'
+import type { BizFormItemUnion, BizPlaceHolderExtra, BizRealExtra } from '../BizFormItemUnion'
+import { BizFormHelper } from '../helper'
+
+function createFormItem(extra: Partial<BizRealExtra & BizPlaceHolderExtra>): FormItemUnion {
+  return {
+    name: 'testField',
+    type: 'input',
+    label: '测试字段',
+    extra,
+  }
+}
+
+describe('BizFormHelper', () => {
+  it('should be defined', () => {
+    expect(BizFormHelper).toBeDefined()
+  })
+
+  it('should be able to correctly identify `BizFormItemUnion`', () => {
+    expect(BizFormHelper.isBizFormItem(createFormItem({}))).toBe(false)
+    // needs to include both `biz` and `bizName`
+    expect(BizFormHelper.isBizFormItem(createFormItem({ biz: true }))).toBe(false)
+    expect(BizFormHelper.isBizFormItem(createFormItem({ bizName: 'TestBiz' }))).toBe(false)
+    expect(BizFormHelper.isBizFormItem(createFormItem({ biz: true, bizName: 'TestBiz' }))).toBe(
+      true,
+    )
+  })
+
+  it('should be able to correctly identify `BizFormItemUnion<BizPlaceHolderExtra>`', () => {
+    // also needs to additionally include `bizLabel`
+    expect(BizFormHelper.isBizFormItemPlaceholder(createFormItem({}))).toBe(false)
+    expect(
+      BizFormHelper.isBizFormItemPlaceholder(createFormItem({ biz: true, bizName: 'TestBiz' })),
+    ).toBe(false)
+    expect(
+      BizFormHelper.isBizFormItemPlaceholder(
+        createFormItem({ biz: true, bizName: 'TestBiz', bizLabel: 'BizPlaceholderLabel' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('should be able to correctly identify `BizFormItemUnion<BizRealExtra>`', () => {
+    // also needs to additionally include `bizField` and `bizKey`
+    expect(BizFormHelper.isBizFormItemReal(createFormItem({}))).toBe(false)
+    expect(BizFormHelper.isBizFormItemReal(createFormItem({ biz: true, bizName: 'TestBiz' }))).toBe(
+      false,
+    )
+    expect(
+      BizFormHelper.isBizFormItemReal(
+        createFormItem({ biz: true, bizName: 'TestBiz', bizKey: 'bizKey' }),
+      ),
+    ).toBe(false)
+    expect(
+      BizFormHelper.isBizFormItemReal(
+        createFormItem({ biz: true, bizName: 'TestBiz', bizField: 'bizField' }),
+      ),
+    ).toBe(false)
+    expect(
+      BizFormHelper.isBizFormItemReal(
+        createFormItem({
+          biz: true,
+          bizName: 'TestBiz',
+          bizKey: 'bizKey',
+          bizField: 'bizField',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  const items = [
+    createFormItem({}), // FormItemUnion
+    createFormItem({ biz: true, bizName: 'Biz1', bizLabel: 'Biz1Label' }), // BizFormItemUnion<BizPlaceholderExtra>
+    createFormItem({ biz: true, bizName: 'Biz1', bizKey: 'Biz2Key', bizField: 'Biz2Field' }), // BizFormItemUnion<BizRealExtra>
+    // BizFormItemUnion<BizPlaceholderExtra>
+    createFormItem({ biz: true, bizName: 'Biz2', bizLabel: 'Biz2Label' }),
+    // BizFormItemUnion<BizRealExtra>
+    createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key1', bizField: 'Biz2Field1' }), // first group
+    createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key1', bizField: 'Biz2Field2' }),
+    createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key2', bizField: 'Biz2Field1' }), // second group
+    createFormItem({ biz: true, bizName: 'Biz2', bizKey: 'Biz2key2', bizField: 'Biz2Field2' }),
+  ] as const
+
+  it('should be able to filter `BizFormItemUnion[]`', () => {
+    // all `BizFormItemUnion`
+    expect(BizFormHelper.filterBizFormItems(items)).toEqual(items.slice(1))
+    // all matched `BizFormItemUnion`
+    expect(BizFormHelper.filterBizFormItems(items, { bizName: 'Biz2' })).toEqual(items.slice(3))
+    expect(
+      BizFormHelper.filterBizFormItems(items, { bizName: 'Biz2', bizKey: 'Biz2key1' }),
+    ).toEqual(items.slice(4, 6))
+    expect(
+      BizFormHelper.filterBizFormItems(items, { bizName: 'Biz2', bizField: 'Biz2Field1' }),
+    ).toEqual([items[4], items[6]])
+  })
+
+  it('should be able to filter `BizFormItemUnion<BizPlaceHolderExtra>[]`', () => {
+    // all `BizFormItemUnion<BizPlaceHolderExtra>`
+    expect(BizFormHelper.filterBizFormItemsPlaceholder(items)).toEqual([items[1], items[3]])
+    // all matched `BizFormItemUnion<BizPlaceHolderExtra>`
+    expect(BizFormHelper.filterBizFormItemsPlaceholder(items, { bizName: 'Biz2' })).toEqual([
+      items[3],
+    ])
+    expect(BizFormHelper.filterBizFormItemsPlaceholder(items, { bizLabel: 'Biz1Label' })).toEqual([
+      items[1],
+    ])
+
+    // try to find the fields of `BizFormItemUnion<BizRealExtra>`, should not find any items
+    expect(
+      BizFormHelper.filterBizFormItemsPlaceholder(items, { bizName: 'Biz2', bizKey: 'Biz2key1' }),
+    ).toEqual([])
+  })
+
+  it('should be able to filter `BizFormItemUnion<BizRealExtra>[]`', () => {
+    // all `BizFormItemUnion<BizRealExtra>`
+    expect(BizFormHelper.filterBizFormItemsReal(items)).toEqual([
+      ...items.slice(2, 3),
+      ...items.slice(4),
+    ])
+    // all matched `BizFormItemUnion<BizRealExtra>`
+    expect(BizFormHelper.filterBizFormItemsReal(items, { bizName: 'Biz2' })).toEqual(items.slice(4))
+    expect(
+      BizFormHelper.filterBizFormItemsReal(items, { bizName: 'Biz2', bizField: 'Biz2Field1' }),
+    ).toEqual([items[4], items[6]])
+
+    // try to find the fields of `BizFormItemUnion<BizPlaceHolderExtra>`, should not find any items
+    expect(
+      BizFormHelper.filterBizFormItemsReal(items, {
+        bizName: 'Biz1',
+        bizLabel: 'Biz1Label',
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('BizFormHelper.findBizValuesMap', () => {
+  const items: BizFormItemUnion<BizRealExtra>[] = [
+    { name: 'name1', label: 'label1', type: 'input' },
+    { name: 'name2', label: 'label2', type: 'input' },
+    {
+      name: 'name3',
+      label: 'label3',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz1', bizKey: 'Biz1Key1', bizField: 'Biz1Field1' },
+    },
+    {
+      name: 'name4',
+      label: 'label4',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz1', bizKey: 'Biz1Key1', bizField: 'Biz1Field2' },
+    },
+    {
+      name: 'name5',
+      label: 'label5',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz1', bizKey: 'Biz1Key2', bizField: 'Biz1Field1' },
+    },
+    {
+      name: 'name6',
+      label: 'label6',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz1', bizKey: 'Biz1Key2', bizField: 'Biz1Field2' },
+    },
+    {
+      name: 'name7',
+      label: 'label7',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz2', bizKey: 'Biz2Key1', bizField: 'Biz2Field' },
+    },
+    {
+      name: 'name8',
+      label: 'label8',
+      type: 'input',
+      extra: { biz: true, bizName: 'Biz2', bizKey: 'Biz2Key2', bizField: 'Biz2Field' },
+    },
+  ]
+
+  const data = {
+    name1: 'value1',
+    name2: 'value2',
+    name3: 'value3',
+    name4: 'value4',
+    name5: 'value5',
+    name6: 'value6',
+    name7: 'value7',
+    name8: 'value8',
+  }
+
+  it('should be able to find `BizValuesMap`', () => {
+    const result1 = BizFormHelper.findBizValuesMap(data, items, 'Biz1', [
+      'Biz1Field2',
+      'Biz1Field1',
+    ])
+    expect(result1['Biz1Key1']).toBeDefined()
+    expect(result1['Biz1Key2']).toBeDefined()
+    expect(result1['Biz1Key1']).toEqual([data.name4, data.name3])
+    expect(result1['Biz1Key2']).toEqual([data.name6, data.name5])
+  })
+})

--- a/packages/base/src/biz-form/helper.ts
+++ b/packages/base/src/biz-form/helper.ts
@@ -77,7 +77,7 @@ export class BizFormHelper {
 
   /**
    * 查找 `formData` 中的业务数据的值的分组，组名为 `bizKey`
-   * @deprecated
+   * @deprecated 已弃用，请用 `BizFormAnalyzer` 类的 `getDataAnalysisTree()` 方法替代
    * @param data 表单数据
    * @param items 表单项
    * @param bizName 业务名称

--- a/packages/base/src/biz-form/helper.ts
+++ b/packages/base/src/biz-form/helper.ts
@@ -1,12 +1,16 @@
 import type { FormItemUnion } from '../form'
 import type { BizFormItemUnion, BizPlaceHolderExtra, BizRealExtra } from './BizFormItemUnion'
 
+type FilterBizFormItemsMatchingRule = Partial<
+  Omit<BizPlaceHolderExtra, 'biz'> & Omit<BizRealExtra, 'biz'>
+>
+
 export class BizFormHelper {
   /**
    * 判断一个 `FormItemUnion` 是否是 `BizFormItemUnion`
    */
   static isBizFormItem(item: FormItemUnion): item is BizFormItemUnion {
-    return !!item.extra?.biz
+    return !!item.extra?.biz && !!item.extra?.bizName
   }
 
   /**
@@ -35,8 +39,14 @@ export class BizFormHelper {
   /**
    * 从 `FormItemUnion[]` 中找到所有 `BizFormItemUnion`
    */
-  static filterBizFormItems(items: FormItemUnion[]): BizFormItemUnion[] {
-    return items.filter(BizFormHelper.isBizFormItem)
+  static filterBizFormItems(
+    items: FormItemUnion[],
+    matchingRule?: FilterBizFormItemsMatchingRule,
+  ): BizFormItemUnion[] {
+    return BizFormHelper._matchingBizFormItems(
+      items.filter(BizFormHelper.isBizFormItem),
+      matchingRule,
+    )
   }
 
   /**
@@ -44,23 +54,34 @@ export class BizFormHelper {
    */
   static filterBizFormItemsPlaceholder(
     items: FormItemUnion[],
+    matchingRule?: FilterBizFormItemsMatchingRule,
   ): BizFormItemUnion<BizPlaceHolderExtra>[] {
-    return items.filter(BizFormHelper.isBizFormItemPlaceholder)
+    return BizFormHelper._matchingBizFormItems(
+      items.filter(BizFormHelper.isBizFormItemPlaceholder),
+      matchingRule,
+    )
   }
 
   /**
    * 从 `FormItemUnion[]` 中找到所有真实 `BizFormItemUnion`
    */
-  static filterBizFormItemsReal(items: FormItemUnion[]): BizFormItemUnion<BizRealExtra>[] {
-    return items.filter(BizFormHelper.isBizFormItemReal)
+  static filterBizFormItemsReal(
+    items: FormItemUnion[],
+    matchingRule?: FilterBizFormItemsMatchingRule,
+  ): BizFormItemUnion<BizRealExtra>[] {
+    return BizFormHelper._matchingBizFormItems(
+      items.filter(BizFormHelper.isBizFormItemReal),
+      matchingRule,
+    )
   }
 
   /**
-   * 查找 `formData` 中的业务数据
+   * 查找 `formData` 中的业务数据的值的分组，组名为 `bizKey`
+   * @deprecated
    * @param data 表单数据
    * @param items 表单项
    * @param bizName 业务名称
-   * @param bizFields 返回的 `bizValue` 数组，返回值将按照该数组的顺序排列
+   * @param bizFields 业务字段数组，返回值将按照该数组的顺序排列
    * @returns
    */
   static findBizValuesMap(
@@ -68,24 +89,40 @@ export class BizFormHelper {
     items: FormItemUnion[],
     bizName: string,
     bizFields: string[],
-  ) {
+  ): Record<string, any[]> {
     const bizItems = BizFormHelper.filterBizFormItemsReal(items)
-    const map: Record<string, any[]> = {}
+    const result: Record<string, any[]> = {}
 
     bizItems.forEach((item) => {
       const extra = item.extra!
       if (extra.bizName !== bizName) return
 
-      const list = map[extra.bizKey] ?? []
+      const list = result[extra.bizKey] ?? []
 
       bizFields.forEach((field, index) => {
         if (extra.bizField === field) {
           list[index] = data[item.name]
         }
       })
-      map[extra.bizKey] = list
+      result[extra.bizKey] = list
     })
 
-    return map
+    return result
+  }
+
+  /**
+   * 找到所有匹配规则的 `BizFormItemUnion`
+   * @param items
+   * @param matchingRule
+   * @returns
+   */
+  private static _matchingBizFormItems<T extends BizFormItemUnion>(
+    items: T[],
+    matchingRule?: FilterBizFormItemsMatchingRule,
+  ): T[] {
+    if (!matchingRule) return items
+    return items.filter((item) =>
+      Object.entries(matchingRule).every(([key, value]) => (item.extra as any)[key] === value),
+    )
   }
 }

--- a/packages/base/src/form-analyzer/BizFormAnalyzer.ts
+++ b/packages/base/src/form-analyzer/BizFormAnalyzer.ts
@@ -1,0 +1,91 @@
+import type { FormItemUnion, PartialFormItemIntersectionWithoutNameAndType } from '../form'
+import { BizFormHelper, BizFormItemUnion, BizRealExtra } from '../biz-form'
+import { FormAnalyzer } from './FormAnalyzer'
+
+/**
+ * 业务表单项的分析树结构
+ * - 第 1 层为 `bizName`，即不同的业务控件
+ * - 第 2 层为 `bizKey`，即同一业务控件的不同实例标识（用来区分同一种业务控件的不同分组）
+ * - 第 3 层为 `bizField`，即业务控件下的某个字段
+ */
+export type BizAnalysisTree<T> = {
+  [bizName: string]: {
+    [bizKey: string]: {
+      [bizField: string]: T
+    }
+  }
+}
+
+/**
+ * 业务表单分析器
+ *
+ * 注意：
+ * 这里仅解析 `items` 中的 `BizFormItemUnion<BizRealExtra>` 项，
+ * 将忽略 `BizFormItemUnion<BizPlaceholderExtra>`
+ */
+export class BizFormAnalyzer extends FormAnalyzer {
+  private _bizItems: BizFormItemUnion<BizRealExtra>[] = []
+  private _bizItemMap = new Map<string, BizFormItemUnion<BizRealExtra>>()
+
+  constructor(items: FormItemUnion[]) {
+    super(items)
+    this._bizItems = BizFormHelper.filterBizFormItemsReal(items)
+    this._bizItems.forEach((item) => this._bizItemMap.set(item.name, item))
+  }
+
+  getBizItems() {
+    return this._bizItems
+  }
+
+  findBizItems(
+    rule?: PartialFormItemIntersectionWithoutNameAndType,
+    bizRule?: Partial<Omit<BizRealExtra, 'biz'>>,
+  ) {
+    const matched = this.matchingItems(this._bizItems, rule)
+    return !bizRule ? matched : BizFormHelper.filterBizFormItemsReal(matched, bizRule)
+  }
+
+  /**
+   * 获取一棵叶子为业务表单项的分析树
+   * @returns
+   */
+  getBizItemAnalysisTree(): BizAnalysisTree<BizFormItemUnion<BizRealExtra>> {
+    return this.generateBizAnalysisTree((item) => item)
+  }
+
+  /**
+   * 获取一棵叶子为表单数据的分析树
+   * @param formData
+   * @returns
+   */
+  getDataAnalysisTree(formData: Record<string, any>): BizAnalysisTree<any> {
+    return this.generateBizAnalysisTree((item) => formData[item.name])
+  }
+
+  /**
+   * 生成一棵业务分析树
+   * @param cb `(item: BizFormItemUnion<BizRealExtra>) => T` 将对每一项调用该回调函数，返回值放入树的叶子节点
+   * @returns
+   */
+  generateBizAnalysisTree<T>(cb: (item: BizFormItemUnion<BizRealExtra>) => T): BizAnalysisTree<T> {
+    const tree: BizAnalysisTree<T> = {}
+
+    this._bizItems.forEach((item) => {
+      const extra = this.getExtra(item)
+      const bizKeyMap = tree[extra.bizName] ?? (tree[extra.bizName] = {})
+      const bizFieldMap = bizKeyMap[extra.bizKey] ?? (bizKeyMap[extra.bizKey] = {})
+      const result = cb(item)
+      bizFieldMap[extra.bizField] = result
+    })
+
+    return tree
+  }
+
+  private getExtra(bizItem: BizFormItemUnion<BizRealExtra>): BizRealExtra {
+    return bizItem.extra!
+  }
+}
+
+export function createBizFormAnalyzer(items: FormItemUnion[]) {
+  return new BizFormAnalyzer(items)
+}

--- a/packages/base/src/form-analyzer/FormAnalyzer.ts
+++ b/packages/base/src/form-analyzer/FormAnalyzer.ts
@@ -1,0 +1,37 @@
+import type { FormItemUnion, PartialFormItemIntersection } from '../form'
+
+/**
+ * 表单分析器
+ */
+export class FormAnalyzer {
+  private _items: FormItemUnion[] = []
+  private _itemMap = new Map<string, FormItemUnion>()
+
+  constructor(items: FormItemUnion[]) {
+    this._items = items
+    this._items.forEach((item) => this._itemMap.set(item.name, item))
+  }
+
+  getItems() {
+    return this._items
+  }
+
+  findItems(rule?: PartialFormItemIntersection) {
+    return this.matchingItems(this._items, rule)
+  }
+
+  protected matchingItems<T extends FormItemUnion>(items: T[], rule?: PartialFormItemIntersection) {
+    if (!rule) return items
+    return items.filter((item: any) =>
+      Object.entries(rule).every(([key, value]) => item[key] === value),
+    )
+  }
+
+  getItem(name: string) {
+    return this._itemMap.get(name)
+  }
+}
+
+export function createFormAnalyzer(items: FormItemUnion[]) {
+  return new FormAnalyzer(items)
+}

--- a/packages/base/src/form-analyzer/__tests__/FormAnalyzer.spec.ts
+++ b/packages/base/src/form-analyzer/__tests__/FormAnalyzer.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { FormItemUnion } from '../../form'
+import { createFormAnalyzer, FormAnalyzer } from '../FormAnalyzer'
+
+describe('FormAnalyzer', () => {
+  it('should be defined', () => {
+    expect(FormAnalyzer).toBeDefined()
+    expect(createFormAnalyzer).toBeDefined()
+    expect(createFormAnalyzer([])).toBeInstanceOf(FormAnalyzer)
+  })
+
+  const items: FormItemUnion[] = [
+    { name: 'name1', label: 'Label1', type: 'input' },
+    { name: 'name2', label: 'Label2', type: 'select' },
+    { name: 'name3', label: 'Label2', type: 'input', inputType: 'textarea' },
+  ]
+
+  it('should be able to getItem', () => {
+    const formAnalyzer = createFormAnalyzer(items)
+
+    expect(formAnalyzer.getItems()).toBe(items)
+    expect(formAnalyzer.getItem('name1')).toBe(items[0])
+    expect(formAnalyzer.getItem('name2')).toBe(items[1])
+    expect(formAnalyzer.getItem('name3')).toBe(items[2])
+  })
+
+  it('should be able to matching items', () => {
+    const formAnalyzer = createFormAnalyzer(items)
+
+    expect(formAnalyzer.findItems()).toEqual(items)
+    expect(formAnalyzer.findItems({})).toEqual(items)
+    expect(formAnalyzer.findItems({ type: 'input' })).toEqual([items[0], items[2]])
+    expect(formAnalyzer.findItems({ type: 'select' })).toEqual([items[1]])
+    expect(formAnalyzer.findItems({ type: 'input', inputType: 'textarea' })).toEqual([items[2]])
+    expect(formAnalyzer.findItems({ inputType: 'textarea' })).toEqual([items[2]])
+    expect(formAnalyzer.findItems({ selectMultiple: true })).toEqual([])
+  })
+})

--- a/packages/base/src/form-analyzer/index.ts
+++ b/packages/base/src/form-analyzer/index.ts
@@ -1,0 +1,2 @@
+export * from './FormAnalyzer'
+export * from './BizFormAnalyzer'

--- a/packages/base/src/form/index.ts
+++ b/packages/base/src/form/index.ts
@@ -1,3 +1,5 @@
+import type { PickInUnion, TupleOmit, TupleToUnion, UnionToIntersection } from '@cphayim-enc/shared'
+
 import type { CascaderFormItem } from './cascader'
 import type { CheckboxFormItem } from './checkbox'
 import type { CustomFormItem } from './custom'
@@ -10,41 +12,43 @@ import type { SwitchFormItem } from './switch'
 import type { TimeFormItem } from './time'
 import type { UploadFormItem } from './upload'
 
+type FormItemTuple<F = string, E = any> = [
+  InputFormItem<F, E>,
+  SelectFormItem<F, E>,
+  CascaderFormItem<F, E>,
+  DateFormItem<F, E>,
+  TimeFormItem<F, E>,
+  UploadFormItem<F, E>,
+  SwitchFormItem<F, E>,
+  RadioFormItem<F, E>,
+  CheckboxFormItem<F, E>,
+  RateFormItem<F, E>,
+  CustomFormItem<F, E>,
+]
+
 /**
  * 所有 `FormItem` 的联合类型，根据 `type` 进行类型收窄
  */
-export type FormItemUnion<F = string, E = any> =
-  | InputFormItem<F, E>
-  | SelectFormItem<F, E>
-  | CascaderFormItem<F, E>
-  | DateFormItem<F, E>
-  | TimeFormItem<F, E>
-  | UploadFormItem<F, E>
-  | SwitchFormItem<F, E>
-  | RadioFormItem<F, E>
-  | CheckboxFormItem<F, E>
-  | RateFormItem<F, E>
-  | CustomFormItem<F, E>
+export type FormItemUnion<F = string, E = any> = TupleToUnion<FormItemTuple<F, E>>
 
-type PickInUnion<T, F extends string> = Pick<Extract<T, { [K in F]: any }>, F>
-type OmitInUnionToInsertion<T, F extends string> = Extract<T, { [k in F]: any }> extends infer U
-  ? { [K in keyof U]: Omit<U, F> }[keyof U]
-  : never
-
-/**
- * 包含所有 FormItem 可选属性的类型
- * - 取 `FormItemUnion` 中所有 `FormItem` 的 `type` 的类型做联合类型
- * - 取 `FormItemUnion` 中所有 `FormItem` 移除 `type` 后做交叉类型（`type` 不相交）
- */
-export type PartialFormItemUnion<F = string, E = any> = Partial<
-  PickInUnion<FormItemUnion<F, E>, 'type'> & OmitInUnionToInsertion<FormItemUnion<F, E>, 'type'>
+type FormItemUnionWithoutType<F = string, E = any> = TupleToUnion<
+  TupleOmit<FormItemTuple<F, E>, 'type'>
 >
 
 /**
- * 不含有 `name` 和 `type` 的 `PartialFormItemUnion`
+ * 包含所有 FormItem 可选属性的类型
+ * - 取 `FormItemUnion` 中所有 `FormItem` 的 `type` 的类型组成的联合类型
+ * - 取 `FormItemUnionWithoutType` 中所有 `FormItem 做交叉类型
  */
-export type PartialFormItemUnionWithoutNameAndType<F = string, E = any> = Omit<
-  PartialFormItemUnion<F, E>,
+export type PartialFormItemIntersection<F = string, E = any> = Partial<
+  PickInUnion<FormItemUnion<F, E>, 'type'> & UnionToIntersection<FormItemUnionWithoutType>
+>
+
+/**
+ * 不包含 `name` 和 `type` 的 `PartialFormItemIntersection`
+ */
+export type PartialFormItemIntersectionWithoutNameAndType<F = string, E = any> = Omit<
+  PartialFormItemIntersection<F, E>,
   'name' | 'type'
 >
 

--- a/packages/base/src/form/index.ts
+++ b/packages/base/src/form/index.ts
@@ -5,12 +5,14 @@ import type { DateFormItem } from './date'
 import type { InputFormItem } from './input'
 import type { RadioFormItem } from './radio'
 import type { RateFormItem } from './rate'
-
 import type { SelectFormItem } from './select'
 import type { SwitchFormItem } from './switch'
 import type { TimeFormItem } from './time'
 import type { UploadFormItem } from './upload'
 
+/**
+ * 所有 `FormItem` 的联合类型，根据 `type` 进行类型收窄
+ */
 export type FormItemUnion<F = string, E = any> =
   | InputFormItem<F, E>
   | SelectFormItem<F, E>
@@ -24,19 +26,26 @@ export type FormItemUnion<F = string, E = any> =
   | RateFormItem<F, E>
   | CustomFormItem<F, E>
 
-// Used for default configuration
-export type OmitPartialFormItem = Partial<
-  Omit<InputFormItem, 'type' | 'name'> &
-    Omit<SelectFormItem, 'type' | 'name'> &
-    Omit<CascaderFormItem, 'type' | 'name'> &
-    Omit<DateFormItem, 'type' | 'name'> &
-    Omit<TimeFormItem, 'type' | 'name'> &
-    Omit<UploadFormItem, 'type' | 'name'> &
-    Omit<SwitchFormItem, 'type' | 'name'> &
-    Omit<RadioFormItem, 'type' | 'name'> &
-    Omit<CheckboxFormItem, 'type' | 'name'> &
-    Omit<RateFormItem, 'type' | 'name'> &
-    Omit<CustomFormItem, 'type' | 'name'>
+type PickInUnion<T, F extends string> = Pick<Extract<T, { [K in F]: any }>, F>
+type OmitInUnionToInsertion<T, F extends string> = Extract<T, { [k in F]: any }> extends infer U
+  ? { [K in keyof U]: Omit<U, F> }[keyof U]
+  : never
+
+/**
+ * 包含所有 FormItem 可选属性的类型
+ * - 取 `FormItemUnion` 中所有 `FormItem` 的 `type` 的类型做联合类型
+ * - 取 `FormItemUnion` 中所有 `FormItem` 移除 `type` 后做交叉类型（`type` 不相交）
+ */
+export type PartialFormItemUnion<F = string, E = any> = Partial<
+  PickInUnion<FormItemUnion<F, E>, 'type'> & OmitInUnionToInsertion<FormItemUnion<F, E>, 'type'>
+>
+
+/**
+ * 不含有 `name` 和 `type` 的 `PartialFormItemUnion`
+ */
+export type PartialFormItemUnionWithoutNameAndType<F = string, E = any> = Omit<
+  PartialFormItemUnion<F, E>,
+  'name' | 'type'
 >
 
 export * from './base'

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -2,6 +2,7 @@ import { version } from '../package.json'
 
 export * from './form'
 export * from './biz-form'
+export * from './form-analyzer'
 export * from './utils'
 
 export const ENC_VERSION = version

--- a/packages/extension-form-editor/src/FormEditorBiz.ts
+++ b/packages/extension-form-editor/src/FormEditorBiz.ts
@@ -12,4 +12,9 @@ export type FormEditorBizFeature = Pick<BizPlaceHolderExtra, 'bizName' | 'bizLab
    * "占位项" <=> "实际项" | "实际项"[] 的转换器
    */
   bizTransformer: BizTransformer
+  /**
+   * 是否为单例（编辑器将阻止该业务控件被添加多次）
+   * @default false
+   */
+  bizSingleton?: boolean
 }

--- a/packages/extension-form-editor/src/FormEditorConfig.ts
+++ b/packages/extension-form-editor/src/FormEditorConfig.ts
@@ -1,4 +1,4 @@
-import type { FormEditorPreset } from './FormEditorPreset'
+import { FormEditorPreset } from './FormEditorPreset'
 import type { FormEditorBizFeature } from './FormEditorBiz'
 
 export enum FormEditorOperation {
@@ -58,4 +58,23 @@ export interface FormEditorConfig {
    * formItem 为空时的提示文字
    */
   formItemEmptyText?: string
+  /**
+   * 是否同步 `options` 中的 `label` 和 `value`
+   *
+   * 这会影响到编辑器中所有含选项的配置行为
+   * - `true`: 禁用选项的 `value` 编辑，自动同步 `label` 的值到 `value`
+   * - `false`: 可以单独编辑 `label` 和 `value`
+   *
+   * @default false
+   */
+  syncOptionsLabelAndValue?: boolean
+}
+
+export const DEFAULT_FORM_EDITOR_CONFIG: FormEditorConfig = {
+  // default enable all
+  presets: Object.values(FormEditorPreset),
+  bizFeatures: [],
+  randomNameOnly: false,
+  randomNameLength: 8,
+  syncOptionsLabelAndValue: false,
 }

--- a/packages/extension-vue-form-editor/src/components/form-edit-panel/FormEditPanel.vue
+++ b/packages/extension-vue-form-editor/src/components/form-edit-panel/FormEditPanel.vue
@@ -66,10 +66,12 @@ const handleAddItemByFeature = ({
 
   // 直接点击左侧面板的功能按钮触发不存在 index，添加到尾部
   if (isNone(index)) index = formItems.value.length
+
   const rStr = randomStr(config.value.randomNameLength ?? 8)
   const item = isPresetFeature(feature)
     ? feature.getItem(rStr)
     : feature.bizTransformer.toPlaceHolder([], rStr)
+
   handleAddItem({ index, item })
   emitter.emit('select-item', { type: 'adding', item, index })
 }
@@ -109,7 +111,13 @@ watch(
   <DndProvider :backend="props.backend || HTML5Backend">
     <div class="enc-edit-panel">
       <!-- left features panel -->
-      <EncLeftPanel :config="config" :emitter="emitter" class="enc-flex-shrink-0" />
+      <EncLeftPanel
+        :config="config"
+        :items="formItems"
+        :emitter="emitter"
+        class="enc-flex-shrink-0"
+      />
+
       <!-- center items panel -->
       <EncCenterPanel
         v-model:items="formItems"
@@ -118,6 +126,7 @@ watch(
         :selectedItem="selectedItem"
         class="enc-flex-1"
       />
+
       <!-- right detail edit panel -->
       <EncRightPanel
         :config="config"

--- a/packages/extension-vue-form-editor/src/components/form-edit-panel/left-panel/DrawableFeature.vue
+++ b/packages/extension-vue-form-editor/src/components/form-edit-panel/left-panel/DrawableFeature.vue
@@ -3,10 +3,11 @@
 import { computed, toRef } from 'vue'
 import { useDrag } from '@ombro/dnd-vue'
 
-import { useEventLock } from '@cphayim-enc/vue'
+import { BizFormHelper, FormItemUnion, useEventLock } from '@cphayim-enc/vue'
 import {
   FormEditorBizFeature,
   FormEditorPresetFeature,
+  isBizFeature,
   isPresetFeature,
 } from '@cphayim-enc/extension-form-editor'
 import { DnDTypes, type DragFeature } from '../dnd'
@@ -15,6 +16,7 @@ import type { FormEditorInternalEmitter } from '..'
 defineOptions({ name: 'EncDrawableFeature' })
 
 const props = defineProps<{
+  items: FormItemUnion[]
   feature: FormEditorPresetFeature | FormEditorBizFeature
   emitter: FormEditorInternalEmitter
 }>()
@@ -45,6 +47,17 @@ const desc = computed(() =>
   isPresetFeature(feature.value) ? feature.value.presetDesc : feature.value.bizDesc,
 )
 
+const disabled = computed(() => {
+  if (!isBizFeature(feature.value)) return false
+
+  // items 中是否已经存在该 bizName 的项
+  const isExistCurrentBiz = !!BizFormHelper.filterBizFormItems(props.items, {
+    bizName: feature.value.bizName,
+  }).length
+
+  return feature.value.bizSingleton ? isExistCurrentBiz : false
+})
+
 const handleAdd = useEventLock(() => {
   props.emitter.emit('add-item-by-feature', { feature: props.feature })
 })
@@ -52,20 +65,34 @@ const handleAdd = useEventLock(() => {
 
 <template>
   <div :data-col-span="colSpan">
-    <div @click="handleAdd" :ref="drag" class="enc-edit-panel-feature-btn">
+    <div @click="handleAdd" :ref="drag" class="enc-edit-panel-feature-btn" :disabled="disabled">
       <span>{{ label }}</span>
       <span v-if="desc" class="enc-text-[12px] enc-text-gray-500 enc-font-light">{{ desc }}</span>
+      <span v-if="isBizFeature(feature) && feature.bizSingleton" class="enc-biz-singleton-feature">
+        单
+      </span>
     </div>
   </div>
 </template>
 
 <style>
 .enc-edit-panel-feature-btn {
+  @apply enc-relative enc-overflow-hidden;
   @apply enc-flex enc-flex-col enc-items-center enc-justify-center;
   @apply enc-min-h-[40px] enc-py-[5px] enc-mb-[10px] enc-mx-[5px] enc-cursor-pointer enc-rounded-[4px];
   @apply enc-text-gray-500 enc-text-[14px] enc-bg-gray-100;
   &:hover {
     @apply enc-bg-gray-200;
   }
+  &[disabled='true'] {
+    @apply enc-pointer-events-none;
+    @apply enc-opacity-60 enc-cursor-not-allowed;
+  }
+}
+.enc-biz-singleton-feature {
+  @apply enc-absolute enc-top-1/2 enc-right-[5px] -enc-translate-y-1/2;
+  @apply enc-flex enc-justify-center enc-items-center enc-opacity-50;
+  @apply enc-w-[30px] enc-h-[30px] enc-border-2 enc-border-solid enc-border-gray-300 enc-rounded-full;
+  @apply enc-text-[18px] enc-text-gray-400;
 }
 </style>

--- a/packages/extension-vue-form-editor/src/components/form-edit-panel/left-panel/LeftPanel.vue
+++ b/packages/extension-vue-form-editor/src/components/form-edit-panel/left-panel/LeftPanel.vue
@@ -12,10 +12,12 @@ import {
 import { EncFormEditorTip } from '../../form-editor-tip'
 import type { FormEditorInternalEmitter } from '..'
 import DrawableFeature from './DrawableFeature.vue'
+import type { FormItemUnion } from '@cphayim-enc/base'
 
 defineOptions({ name: 'EncLeftPanel' })
 
 const props = defineProps<{
+  items: FormItemUnion[]
   config: FormEditorConfig
   emitter: FormEditorInternalEmitter
 }>()
@@ -29,23 +31,25 @@ const bizFeatures = computed(() => props.config.bizFeatures)
 <template>
   <div class="enc-edit-panel-left-panel">
     <EncFormEditorTip :content="formEditorTips.left" />
+
     <!-- preset features -->
     <template v-for="group in presetFeatureGroups" :key="group.groupName">
       <div v-if="group.features.length" class="enc-edit-panel-feature-group">
         <div class="enc-edit-panel-feature-group-name">{{ group.groupName }}</div>
         <div class="enc-flex enc-flex-wrap">
           <template v-for="feature in group.features" :key="feature.presetName">
-            <DrawableFeature :feature="feature" :emitter="props.emitter" />
+            <DrawableFeature :feature="feature" :emitter="props.emitter" :items="props.items" />
           </template>
         </div>
       </div>
     </template>
+
     <!-- biz features -->
     <div v-if="bizFeatures" class="enc-edit-panel-feature-group">
       <div class="enc-edit-panel-feature-group-name">业务/组合型控件</div>
       <div class="enc-flex enc-flex-wrap">
         <template v-for="feature in bizFeatures" :key="feature.presetName">
-          <DrawableFeature :feature="feature" :emitter="props.emitter" />
+          <DrawableFeature :feature="feature" :emitter="props.emitter" :items="props.items" />
         </template>
       </div>
     </div>

--- a/packages/extension-vue-form-editor/src/components/form-editor/FormEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-editor/FormEditor.vue
@@ -5,13 +5,13 @@ import type { FormItemUnion } from '@cphayim-enc/base'
 import { useFormItems } from '@cphayim-enc/vue'
 import {
   BizFeatureFormEditorTransformer,
+  DEFAULT_FORM_EDITOR_CONFIG,
   FormEditorConfig,
   FormEditorOperation,
 } from '@cphayim-enc/extension-form-editor'
 
 import { EncFormPreview } from '../form-preview'
 import { EncFormEditPanel } from '../form-edit-panel'
-import { DEFAULT_FORM_EDITOR_CONFIG } from './config'
 
 defineOptions({ name: 'EncFormEditor' })
 

--- a/packages/extension-vue-form-editor/src/components/form-editor/config.ts
+++ b/packages/extension-vue-form-editor/src/components/form-editor/config.ts
@@ -1,9 +1,0 @@
-import { FormEditorConfig, FormEditorPreset } from '@cphayim-enc/extension-form-editor'
-
-export const DEFAULT_FORM_EDITOR_CONFIG: FormEditorConfig = {
-  // default enable all
-  presets: Object.values(FormEditorPreset),
-  bizFeatures: [],
-  randomNameOnly: false,
-  randomNameLength: 8,
-}

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/checkbox/CheckboxFormItemEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/checkbox/CheckboxFormItemEditor.vue
@@ -65,7 +65,7 @@ initTransformCheckboxOptions()
     <!-- 分组选项 -->
     <EncFieldset v-show="isGroup">
       <template #title>
-        <span class="enc-mr-[8px]">组选项</span>
+        <span class="enc-mr-[8px]">选项配置</span>
         <span
           @click="handleAddOption"
           class="enc-relative enc-z-20 enc-cursor-pointer enc-text-[16px] enc-leading-[24px] enc-text-gray-500 hover:enc-text-green-500"

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/checkbox/CheckboxFormItemOptionEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/checkbox/CheckboxFormItemOptionEditor.vue
@@ -4,7 +4,7 @@ import { useVModel } from '@vueuse/core'
 import type { CheckboxOptions } from '@cphayim-enc/base'
 import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
 
-import { useEditorItems } from '../../../hooks'
+import { useSyncOptionsEditorItems } from '../../../hooks'
 import { COMMON_ENC_FORM_PROPS } from '../common'
 import { CHECKBOX_OPTION_ITEMS } from './items'
 
@@ -16,7 +16,11 @@ const props = defineProps<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue')
-const { EncForm, formRef, formItems } = useEditorItems(CHECKBOX_OPTION_ITEMS, props.config)
+const { EncForm, formRef, formItems } = useSyncOptionsEditorItems(
+  CHECKBOX_OPTION_ITEMS,
+  props.config,
+  modelValue,
+)
 
 const encFormProps = { ...COMMON_ENC_FORM_PROPS, labelWidth: 40 }
 </script>

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/radio/RadioFormItemEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/radio/RadioFormItemEditor.vue
@@ -55,7 +55,7 @@ initTransformRadioOptions()
 
     <EncFieldset>
       <template #title>
-        <span class="enc-mr-[8px]">选项</span>
+        <span class="enc-mr-[8px]">选项配置</span>
         <span
           @click="handleAddOption"
           class="enc-relative enc-z-20 enc-cursor-pointer enc-text-[16px] enc-leading-[24px] enc-text-gray-500 hover:enc-text-green-500"

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/radio/RadioFormItemOptionEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/radio/RadioFormItemOptionEditor.vue
@@ -4,7 +4,7 @@ import { useVModel } from '@vueuse/core'
 import type { RadioOptions } from '@cphayim-enc/base'
 import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
 
-import { useEditorItems } from '../../../hooks'
+import { useSyncOptionsEditorItems } from '../../../hooks'
 import { COMMON_ENC_FORM_PROPS } from '../common'
 import { RADIO_OPTION_ITEMS } from './items'
 
@@ -16,7 +16,11 @@ const props = defineProps<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue')
-const { EncForm, formRef, formItems } = useEditorItems(RADIO_OPTION_ITEMS, props.config)
+const { EncForm, formRef, formItems } = useSyncOptionsEditorItems(
+  RADIO_OPTION_ITEMS,
+  props.config,
+  modelValue,
+)
 
 const encFormProps = { ...COMMON_ENC_FORM_PROPS, labelWidth: 40 }
 </script>

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/select/SelectFormItemEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/select/SelectFormItemEditor.vue
@@ -32,7 +32,7 @@ const handleAddOption = () => {
   if (!modelValue.value.selectOptions) {
     modelValue.value.selectOptions = []
   }
-  modelValue.value.selectOptions?.push({ label: 'label', value: 'value' })
+  modelValue.value.selectOptions?.push({ label: '选项', value: '选项' })
 }
 const handleRemoveOption = (index: number) => {
   modelValue.value?.selectOptions?.splice(index, 1)
@@ -50,7 +50,7 @@ const handleRemoveOption = (index: number) => {
 
     <EncFieldset>
       <template #title>
-        <span class="enc-mr-[8px]">选项</span>
+        <span class="enc-mr-[8px]">选项配置</span>
         <span
           @click="handleAddOption"
           class="enc-relative enc-z-20 enc-cursor-pointer enc-text-[16px] enc-leading-[24px] enc-text-gray-500 hover:enc-text-green-500"

--- a/packages/extension-vue-form-editor/src/components/form-item-editor/select/SelectFormItemOptionEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-item-editor/select/SelectFormItemOptionEditor.vue
@@ -4,7 +4,7 @@ import { useVModel } from '@vueuse/core'
 import type { SelectFormItemOption } from '@cphayim-enc/base'
 import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
 
-import { useEditorItems } from '../../../hooks'
+import { useSyncOptionsEditorItems } from '../../../hooks'
 import { COMMON_ENC_FORM_PROPS } from '../common'
 import { SELECT_OPTION_ITEMS } from './items'
 
@@ -16,7 +16,11 @@ const props = defineProps<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue')
-const { EncForm, formRef, formItems } = useEditorItems(SELECT_OPTION_ITEMS, props.config)
+const { EncForm, formRef, formItems } = useSyncOptionsEditorItems(
+  SELECT_OPTION_ITEMS,
+  props.config,
+  modelValue,
+)
 
 const encFormProps = { ...COMMON_ENC_FORM_PROPS, labelWidth: 40 }
 </script>

--- a/packages/extension-vue-form-editor/src/hooks/__tests__/use-sync-options-editor-items.spec.ts
+++ b/packages/extension-vue-form-editor/src/hooks/__tests__/use-sync-options-editor-items.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import type { FormItemUnion, SelectFormItemOption } from '@cphayim-enc/base'
+import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
+
+import { useSyncOptionsEditorItems } from '../use-sync-editor-options-items'
+import { createTestMockEncForm } from '../../__tests__/mock-enc-form'
+
+function createOptionItems(): FormItemUnion[] {
+  return [
+    { name: 'label', label: '文本', type: 'input', col: 8 },
+    { name: 'value', label: '值', type: 'input', col: 8 },
+    { name: 'disabled', label: '禁用', type: 'checkbox', col: 8 },
+  ]
+}
+
+describe('useSyncOptionsEditorItems', () => {
+  it('should not be sync options when syncOptionsLabelAndValue -> false', async () => {
+    const modelValue = ref<SelectFormItemOption>({ label: '', value: '', disabled: false })
+    const config = ref<FormEditorConfig>({
+      encFormComponent: createTestMockEncForm(),
+      // syncOptionsLabelAndValue: false, // default
+    })
+    const { getItem } = useSyncOptionsEditorItems(createOptionItems(), config.value, modelValue)
+
+    modelValue.value.label = '选项一'
+    await nextTick()
+    expect(modelValue.value.value).toBe('')
+
+    expect(getItem('label')?.col).toBe(8)
+    expect(getItem('value')?.disabled).toBeFalsy()
+    expect(getItem('value')?.hidden).toBeFalsy()
+  })
+
+  it('should be sync options when syncOptionsLabelAndValue -> true', async () => {
+    const modelValue = ref<SelectFormItemOption>({ label: '', value: '', disabled: false })
+    const config = ref<FormEditorConfig>({
+      encFormComponent: createTestMockEncForm(),
+      syncOptionsLabelAndValue: true,
+    })
+    const { getItem } = useSyncOptionsEditorItems(createOptionItems(), config.value, modelValue)
+
+    modelValue.value.label = '选项一'
+    await nextTick()
+    expect(modelValue.value.value).toBe('选项一')
+
+    expect(getItem('label')?.col).toBe(16)
+    expect(getItem('value')?.disabled).toBeTruthy()
+    expect(getItem('value')?.hidden).toBeTruthy()
+  })
+})

--- a/packages/extension-vue-form-editor/src/hooks/index.ts
+++ b/packages/extension-vue-form-editor/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-editor-items'
+export * from './use-sync-editor-options-items'

--- a/packages/extension-vue-form-editor/src/hooks/use-editor-items.ts
+++ b/packages/extension-vue-form-editor/src/hooks/use-editor-items.ts
@@ -5,6 +5,9 @@ import { createErrorMessage } from '@cphayim-enc/shared'
 import { useFormItems } from '@cphayim-enc/vue'
 import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
 
+/**
+ * 表单编辑器表单项
+ */
 export function useEditorItems(items: FormItemUnion[], config: FormEditorConfig) {
   const EncForm = computed(() => {
     if (config.encFormComponent?.name !== 'EncForm')

--- a/packages/extension-vue-form-editor/src/hooks/use-sync-editor-options-items.ts
+++ b/packages/extension-vue-form-editor/src/hooks/use-sync-editor-options-items.ts
@@ -1,0 +1,52 @@
+import { Ref, watchEffect, WritableComputedRef } from 'vue'
+
+import type {
+  CascaderFormItemOption,
+  CheckboxOptions,
+  FormItemUnion,
+  RadioOptions,
+  SelectFormItemOption,
+} from '@cphayim-enc/base'
+import type { FormEditorConfig } from '@cphayim-enc/extension-form-editor'
+
+import { useEditorItems } from './use-editor-items'
+
+type OptionUnion =
+  | undefined
+  | SelectFormItemOption
+  | CascaderFormItemOption
+  | RadioOptions
+  | CheckboxOptions
+
+/**
+ * Options 表单编辑器表单项
+ *
+ * 仅用于 Select, Radio, Checkbox 的 Options 配置项的 items
+ */
+export function useSyncOptionsEditorItems<T extends OptionUnion>(
+  items: FormItemUnion[],
+  config: FormEditorConfig,
+  modelValue: Ref<T> | WritableComputedRef<T>,
+) {
+  const rest = useEditorItems(items, config)
+
+  const { updateItem } = rest
+
+  // 开启键值同步时更新 items，并同步值
+  watchEffect(() => {
+    updateItem('label', {
+      col: config.syncOptionsLabelAndValue ? 16 : 8,
+    })
+    updateItem('value', {
+      disabled: config.syncOptionsLabelAndValue,
+      hidden: config.syncOptionsLabelAndValue,
+    })
+  })
+  watchEffect(() => {
+    if (modelValue.value && config.syncOptionsLabelAndValue) {
+      modelValue.value.value = modelValue.value.label
+    }
+  })
+
+  return { ...rest }
+}

--- a/packages/extension-vue-form-editor/src/index.ts
+++ b/packages/extension-vue-form-editor/src/index.ts
@@ -22,5 +22,4 @@ export const createEncExtensionFormEditor = ({
 export default createEncExtensionFormEditor()
 
 export * from '@cphayim-enc/extension-form-editor'
-export * from './hooks'
 export * from './components'

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -5,7 +5,33 @@ export type IsEmptyObject<Obj extends Record<PropertyKey, unknown>> = [keyof Obj
 export type IsNotEmptyObject<Obj extends Record<PropertyKey, unknown>> =
   IsEmptyObject<Obj> extends true ? false : true
 
-export type TupleUnion<U extends string, R extends string[] = []> = {
-  [S in U]: Exclude<U, S> extends never ? [...R, S] : TupleUnion<Exclude<U, S>, [...R, S]>
-}[U] &
-  string[]
+/**
+ * 元组转联合
+ */
+export type TupleToUnion<T extends any[]> = T[number]
+
+/**
+ * 对元组的每一项 Omit
+ */
+export type TupleOmit<T extends any[], K extends PropertyKey> = {
+  [P in keyof T]: Omit<T[P], K>
+}
+
+/**
+ * 联合转交叉
+ */
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
+
+/**
+ * 对联合类型进行 Pick，并将 Pick 的字段组成联合类型
+ *
+ * @example
+ * ```ts
+ * PickInUnion<{ type: 'a', a1: number } | { type: 'b', b1: string }, 'type'> // { type: 'a' | 'b' }
+ * ```
+ */
+export type PickInUnion<T, F extends PropertyKey> = Pick<Extract<T, { [K in F]: any }>, F>

--- a/packages/vue/src/hooks/use-form-items.ts
+++ b/packages/vue/src/hooks/use-form-items.ts
@@ -1,11 +1,11 @@
 import { computed, isRef, ref, Ref, watchEffect } from 'vue'
 
-import type { FormItemUnion, OmitPartialFormItem } from '@cphayim-enc/base'
+import type { FormItemUnion, PartialFormItemUnionWithoutNameAndType } from '@cphayim-enc/base'
 import { createErrorMessage } from '@cphayim-enc/shared'
 
 export function useFormItems<F = string>(
   items: FormItemUnion<F>[] | Ref<FormItemUnion<F>[]>,
-  commonItem?: OmitPartialFormItem,
+  commonItem?: PartialFormItemUnionWithoutNameAndType,
 ) {
   const formItems = ref([]) as Ref<FormItemUnion<F>[]>
 
@@ -18,7 +18,7 @@ export function useFormItems<F = string>(
 
   const getItem = (name: F) => formItemsMap.value.get(name)
 
-  const updateItem = (name: F, updateItem: OmitPartialFormItem) => {
+  const updateItem = (name: F, updateItem: PartialFormItemUnionWithoutNameAndType) => {
     const item = getItem(name)
     if (item) {
       Object.assign(item, updateItem)
@@ -36,7 +36,7 @@ export function useFormItems<F = string>(
 
 function mergeItems<F>(
   items: FormItemUnion<F>[] = [],
-  commonItem: OmitPartialFormItem = {},
+  commonItem: PartialFormItemUnionWithoutNameAndType = {},
 ): FormItemUnion<F>[] {
   return items.map((item) => ({ ...commonItem, ...item }))
 }

--- a/packages/vue/src/hooks/use-form-items.ts
+++ b/packages/vue/src/hooks/use-form-items.ts
@@ -1,11 +1,14 @@
 import { computed, isRef, ref, Ref, watchEffect } from 'vue'
 
-import type { FormItemUnion, PartialFormItemUnionWithoutNameAndType } from '@cphayim-enc/base'
+import type {
+  FormItemUnion,
+  PartialFormItemIntersectionWithoutNameAndType,
+} from '@cphayim-enc/base'
 import { createErrorMessage } from '@cphayim-enc/shared'
 
 export function useFormItems<F = string>(
   items: FormItemUnion<F>[] | Ref<FormItemUnion<F>[]>,
-  commonItem?: PartialFormItemUnionWithoutNameAndType,
+  commonItem?: PartialFormItemIntersectionWithoutNameAndType,
 ) {
   const formItems = ref([]) as Ref<FormItemUnion<F>[]>
 
@@ -18,7 +21,7 @@ export function useFormItems<F = string>(
 
   const getItem = (name: F) => formItemsMap.value.get(name)
 
-  const updateItem = (name: F, updateItem: PartialFormItemUnionWithoutNameAndType) => {
+  const updateItem = (name: F, updateItem: PartialFormItemIntersectionWithoutNameAndType) => {
     const item = getItem(name)
     if (item) {
       Object.assign(item, updateItem)
@@ -36,7 +39,7 @@ export function useFormItems<F = string>(
 
 function mergeItems<F>(
   items: FormItemUnion<F>[] = [],
-  commonItem: PartialFormItemUnionWithoutNameAndType = {},
+  commonItem: PartialFormItemIntersectionWithoutNameAndType = {},
 ): FormItemUnion<F>[] {
   return items.map((item) => ({ ...commonItem, ...item }))
 }

--- a/packages/vue/src/hooks/use-form.ts
+++ b/packages/vue/src/hooks/use-form.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 
-import type { FormItemUnion, OmitPartialFormItem } from '@cphayim-enc/base'
+import type { FormItemUnion, PartialFormItemUnionWithoutNameAndType } from '@cphayim-enc/base'
 import { useFormData } from './use-form-data'
 import { useFormItems } from './use-form-items'
 
@@ -8,12 +8,12 @@ export type UseFormOptions = {
   /**
    * 默认表单配置项，将和 items 的每一项合并
    */
-  commonItem?: OmitPartialFormItem
+  commonItem?: PartialFormItemUnionWithoutNameAndType
   /**
    * 兼容字段，同 commonItem
    * @deprecated
    */
-  defaultProps?: OmitPartialFormItem
+  defaultProps?: PartialFormItemUnionWithoutNameAndType
 }
 
 /**

--- a/packages/vue/src/hooks/use-form.ts
+++ b/packages/vue/src/hooks/use-form.ts
@@ -1,6 +1,9 @@
 import type { Ref } from 'vue'
 
-import type { FormItemUnion, PartialFormItemUnionWithoutNameAndType } from '@cphayim-enc/base'
+import type {
+  FormItemUnion,
+  PartialFormItemIntersectionWithoutNameAndType,
+} from '@cphayim-enc/base'
 import { useFormData } from './use-form-data'
 import { useFormItems } from './use-form-items'
 
@@ -8,12 +11,12 @@ export type UseFormOptions = {
   /**
    * 默认表单配置项，将和 items 的每一项合并
    */
-  commonItem?: PartialFormItemUnionWithoutNameAndType
+  commonItem?: PartialFormItemIntersectionWithoutNameAndType
   /**
    * 兼容字段，同 commonItem
    * @deprecated
    */
-  defaultProps?: PartialFormItemUnionWithoutNameAndType
+  defaultProps?: PartialFormItemIntersectionWithoutNameAndType
 }
 
 /**

--- a/playgrounds/vue/src/views/form-editor/index.vue
+++ b/playgrounds/vue/src/views/form-editor/index.vue
@@ -19,6 +19,7 @@ const formEditorConfig: FormEditorConfig = {
   // presets: [FormEditorPreset.Input],
   bizFeatures: [
     {
+      bizSingleton: true,
       bizName: 'ItemUnitPriceQuantity',
       bizLabel: '报价组合控件',
       bizDesc: '物品+单价+数量',

--- a/playgrounds/vue/src/views/form-editor/index.vue
+++ b/playgrounds/vue/src/views/form-editor/index.vue
@@ -15,6 +15,7 @@ const formEditorConfig: FormEditorConfig = {
     FormEditorOperation.PrintItems,
   ],
   // randomNameOnly: true,
+  syncOptionsLabelAndValue: true,
   // presets: [FormEditorPreset.Input],
   bizFeatures: [
     {


### PR DESCRIPTION
## Affected Packages

- **@cphayim-enc/base**

## Features

**@cphayim-enc/base**

- The filter method provided by `BizFormHelper` supports `matchingRule`.
- Optimized the structure of form item combination types.
  - `OmitPartialFormItem` rename as `PartialFormItemIntersectionWithoutNameAndType`
- Add `FormAnalyzer` and `BizFormAnalyzer`, Analyzer for complex form items


**@cphayim-enc/extension-form-editor**
**@cphayim-enc/extension-vue-form-editor**

- Add `FormEditorConfig.syncOptionsLabelAndValue` option to support key-value sync in edit panel with options (e.g. `Select`, `Checkbox`, `Redio`, etc.)
- Add `FormEditorBizFeature.bizSingleton` option to limit the number of times `bizFeature` can be used in the editor