### PR TITLE
feat(form-editor): add flag to items created by form editor

### DIFF
--- a/packages/extension-form-editor/src/FormEditorConfig.ts
+++ b/packages/extension-form-editor/src/FormEditorConfig.ts
@@ -68,6 +68,13 @@ export interface FormEditorConfig {
    * @default false
    */
   syncOptionsLabelAndValue?: boolean
+  /**
+   * 是否为表单编辑器输出的 FormItemUnion 打标记
+   * - __CREATED_BY_ENC_FORM_EDITOR__: ${ENC_VERSION}
+   *
+   * @default true
+   */
+  markItemCreatedByEditor?: boolean
 }
 
 export const DEFAULT_FORM_EDITOR_CONFIG: FormEditorConfig = {
@@ -77,4 +84,5 @@ export const DEFAULT_FORM_EDITOR_CONFIG: FormEditorConfig = {
   randomNameOnly: false,
   randomNameLength: 8,
   syncOptionsLabelAndValue: false,
+  markItemCreatedByEditor: true,
 }

--- a/packages/extension-form-editor/src/__tests__/utils.spec.ts
+++ b/packages/extension-form-editor/src/__tests__/utils.spec.ts
@@ -1,5 +1,6 @@
+import { ENC_VERSION, FormItemUnion } from '@cphayim-enc/base'
 import { describe, expect, it } from 'vitest'
-import { isBizFeature, isPresetFeature } from '../utils'
+import { isBizFeature, isPresetFeature, markItemsCreatedByEditor } from '../utils'
 
 describe('utils', () => {
   it('should be able to determine whether it is a PresetFeature', () => {
@@ -18,5 +19,16 @@ describe('utils', () => {
     expect(isBizFeature({ bizName: 1, bizLabel: '1' })).toBe(false)
     expect(isBizFeature({ bizName: 1, bizLabel: '1', bizTransformer: {} })).toBe(false)
     expect(isBizFeature({ bizName: '1', bizLabel: '1', bizTransformer: {} })).toBe(true)
+  })
+
+  it('should be add a mark to items', () => {
+    const items: FormItemUnion[] = [
+      { name: 'a', label: 'A', type: 'custom' },
+      { name: 'b', label: 'B', type: 'custom' },
+    ]
+    const markedItems = markItemsCreatedByEditor(items)
+    markedItems.forEach((item) => {
+      expect(item).toMatchObject({ __CREATED_BY_ENC_FORM_EDITOR__: `v${ENC_VERSION}` })
+    })
   })
 })

--- a/packages/extension-form-editor/src/utils.ts
+++ b/packages/extension-form-editor/src/utils.ts
@@ -1,3 +1,4 @@
+import { ENC_VERSION, FormItemUnion } from '@cphayim-enc/base'
 import { isFunction, isNone, isObject, isString } from '@cphayim-enc/shared'
 
 import type { FormEditorBizFeature } from './FormEditorBiz'
@@ -19,4 +20,18 @@ export function isBizFeature(feature: any): feature is FormEditorBizFeature {
     isString(feature.bizLabel) &&
     isObject(feature.bizTransformer)
   )
+}
+
+/**
+ * 为表单编辑器创建的 FormItemUnion 打标
+ */
+export function markItemCreatedByEditor(item: FormItemUnion): FormItemUnion {
+  return {
+    ...item,
+    __CREATED_BY_ENC_FORM_EDITOR__: `v${ENC_VERSION}`,
+  } as any
+}
+
+export function markItemsCreatedByEditor(items: FormItemUnion[]) {
+  return items.map(markItemCreatedByEditor)
 }

--- a/packages/extension-vue-form-editor/src/components/form-editor/FormEditor.vue
+++ b/packages/extension-vue-form-editor/src/components/form-editor/FormEditor.vue
@@ -8,6 +8,7 @@ import {
   DEFAULT_FORM_EDITOR_CONFIG,
   FormEditorConfig,
   FormEditorOperation,
+  markItemsCreatedByEditor,
 } from '@cphayim-enc/extension-form-editor'
 
 import { EncFormPreview } from '../form-preview'
@@ -43,8 +44,15 @@ const { formItems } = useFormItems(
   ),
 )
 
-const getFormItems = () =>
-  BizFeatureFormEditorTransformer.toReal(toRaw(formItems.value), config.value.bizFeatures ?? [])
+const getFormItems = () => {
+  const allRealFormItems = BizFeatureFormEditorTransformer.toReal(
+    toRaw(formItems.value),
+    config.value.bizFeatures ?? [],
+  )
+  return config.value.markItemCreatedByEditor
+    ? markItemsCreatedByEditor(allRealFormItems)
+    : allRealFormItems
+}
 
 const handleConfirm = () => {
   emit('confirm', getFormItems())


### PR DESCRIPTION
### Affected packages

- **@cphayim-enc/extension-form-editor**
- **@cphayim-enc/extension-vue-form-editor**

### Features

**@cphayim-enc/extension-form-editor**
**@cphayim-enc/extension-vue-form-editor**

- Add `FormEditorConfig.markItemCreatedByEditor` option, add `__CREATED_BY_FORM_EDITOR: ${ENC_VERSION}` mark for `FormItemUnion` created by form editor, enabled by default.