### PR TITLE
fix(ex-form-editor): the right panel options set the label width

### DIFF
--- a/packages/extension-vue-form-editor/src/components/fieldset/Fieldset.vue
+++ b/packages/extension-vue-form-editor/src/components/fieldset/Fieldset.vue
@@ -8,7 +8,9 @@ const props = defineProps<{ title?: string }>()
   <fieldset
     class="enc-px-[10px] enc-pb-0 enc-border-solid enc-border enc-border-gray-300 enc-outline-none enc-rounded-[6px] enc-mb-[10px]"
   >
-    <legend class="enc-px-[8px] enc-text-[14px] enc-text-gray-500">
+    <legend
+      class="enc-flex enc-items-center enc-flex-nowrap enc-px-[8px] enc-text-[14px] enc-text-gray-500"
+    >
       <slot name="title">{{ props.title }}</slot>
     </legend>
     <slot />


### PR DESCRIPTION
## Affected Packages

- **@cphayim-enc/extension-vue-form-editor**

## Bug Fixes

- fixed the right panel options set the label width