### PR TITLE
fix(ci): update upload-pages-artifact version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
           pnpm docs:build
           touch docs/.vitepress/dist/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 


### PR DESCRIPTION
Fix [pages deploy](https://github.com/Cphayim/enc/actions/runs/8099334170/job/22134859501) 
```
Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
```
`actions/deploy-pages@v4` requires `actions/upload-artifact@v4`, which is a dependency in `actions/upload-pages-artifact@v3`